### PR TITLE
Clone and delete Satchel to prevent cross-query contamination in calling code.

### DIFF
--- a/source/Meadow-Endpoints.js
+++ b/source/Meadow-Endpoints.js
@@ -59,7 +59,7 @@ var MeadowEndpoints = function()
 
 			Update: require('./crud/Meadow-Endpoint-Update.js'),
 			Updates: require('./crud/Meadow-Endpoint-BulkUpdate.js'),
-			
+
 			Upsert: require('./crud/Meadow-Endpoint-Upsert.js'),
 			Upserts: require('./crud/Meadow-Endpoint-BulkUpsert.js'),
 
@@ -195,7 +195,7 @@ var MeadowEndpoints = function()
 			New: true
 			// GET  [/1.0/SomeEndpoint/Schema/New]
 		});
-		
+
 		/**
 		* Customize an endpoint Authorization Level
 		*
@@ -320,7 +320,7 @@ var MeadowEndpoints = function()
 			{
 				pRestServer.post('/1.0/'+tmpEndpointName+'/Schema/Validate', _CommonServices.bodyParser(), _EndpointAuthenticators.Validate, wireState, _Endpoints.Validate);
 			}
-	
+
 			// Custom single record endpoints
 
 			// Standard CRUD and Count endpoints
@@ -375,7 +375,7 @@ var MeadowEndpoints = function()
 			}
 		};
 
-		
+
 		/**
 		* Emulate a response object
 		*/
@@ -445,12 +445,17 @@ var MeadowEndpoints = function()
 						pRequest.EndpointInvoked = true; //bypass session auth check
 						pRequest.UserSession = { UserID: 0, UserRoleIndex: 0 };
 					}
-					
-					//copy whatever is in here
-					pRequest.Satchel = pOptions.Satchel;
+
+					// The Satchel is a workaround to pass state between query invocation and query decoration
+					// In order to prevent queries from contaminating other queries, we clean up the Satchel
+					// during invocation and decorate it on the fake request object, minimizing the risk of
+					// cross-contamination.
+					//FIXME: We should rework invokeEndpoint to make this state management unnecessary
+					pRequest.Satchel = JSON.parse(JSON.stringify(pOptions.Satchel || {}));
+					delete pOptions.Satchel;
 					//internal invoke mark as authenticated (because this is not called via webservice)
 					pRequest.EndpointAuthenticated = true;
-					
+
 					return fStageComplete();
 				},
 				function(fStageComplete)

--- a/source/crud/Meadow-Endpoint-Update.js
+++ b/source/crud/Meadow-Endpoint-Update.js
@@ -19,9 +19,9 @@ var doAPIUpdateEndpoint = function(pRequest, pResponse, fNext)
 	// This state is the requirement for the UserRoleIndex value in the UserSession object... processed by default as >=
 	// The default here is that any authenticated user can use this endpoint.
 	pRequest.EndpointAuthorizationRequirement = pRequest.EndpointAuthorizationLevels.Update;
-	
+
 	// INJECT: Pre authorization (for instance to change the authorization level)
-	
+
 	if (pRequest.CommonServices.authorizeEndpoint(pRequest, pResponse, fNext) === false)
 	{
 		// If this endpoint fails, it's sent an error automatically.

--- a/source/crud/Meadow-Operation-Update.js
+++ b/source/crud/Meadow-Operation-Update.js
@@ -15,133 +15,131 @@ var libAsync = require('async');
 var doUpdate = function(pRecordToModify, pRequest, pResponse, fCallback, pOptionalCachedUpdatingRecord)
 {
 	// pOptionalCachedUpdatingRecord allows the caller to pass in a record, so the initial read doesn't need to happen.
-    pRequest.MeadowOperation = (typeof(pRequest.MeadowOperation) === 'string') ? pRequest.MeadowOperation : 'Update';
+	pRequest.MeadowOperation = (typeof(pRequest.MeadowOperation) === 'string') ? pRequest.MeadowOperation : 'Update';
 
 	// If there is not a default identifier or cached record, fail
 	if ((pRecordToModify[pRequest.DAL.defaultIdentifier] < 1) && (typeof(pOptionalCachedUpdatingRecord) === 'undefined'))
 	{
 		return fCallback('Record update failure - a valid record ID is required in the passed-in record.');
 	}
-    
-    libAsync.waterfall(
-    	[
-    		function(fStageComplete)
-    		{
-    			pRequest.Record = pRecordToModify;
-    			
-    			if (typeof(pOptionalCachedUpdatingRecord) !== 'undefined')
-    			{
-    				// Use the cached updating record instead of reading a record.
-   					return fStageComplete(false, pOptionalCachedUpdatingRecord);
-    			}
-    			else
-    			{
-	    			var tmpQuery = pRequest.DAL.query;
-	    
-	    			// This is not overloadable.
-	    			tmpQuery.addFilter(pRequest.DAL.defaultIdentifier, pRecordToModify[pRequest.DAL.defaultIdentifier]);
-	    
-	    			// Load the record so we can do security checks on it
-	    			pRequest.DAL.doRead(tmpQuery,
-	    				function(pError, pQuery, pRecord)
-	    				{
-	    					if (!pError && !pRecord)
-	    					{
-	    						//short-circuit: Can't update a record that doesn't exist!
-	    						pError = 'Record not found.';
-	    					}
-	    
-	    					return fStageComplete(pError, pRecord);
-	    				});
-    			}
-    		},
-    		function(pOriginalRecord, fStageComplete)
-    		{
-    			//send the original record to the Authorizer so it can verify ownership/etc
-    			// TODO: Because the authorizer looks in the request for the record, we need to fix this somehow to work asynchronously.
-    			pRequest.UpdatingRecord = pRecordToModify;
-    			pRequest.Record = pOriginalRecord;
-    
-    			pRequest.Authorizers.authorizeRequest('Update', pRequest, function(err)
-    				{
-    					pRequest.Record = pRequest.UpdatingRecord;
-    					return fStageComplete(err);
-    				});
-    		},
-    		function(fStageComplete)
-    		{
-    			//2. INJECT: Record modification before update
-    			pRequest.BehaviorModifications.runBehavior('Update-PreOperation', pRequest, fStageComplete);
-    		},
-    		function (fStageComplete)
-    		{
-    			if (pRequest.MeadowAuthorization)
-    			{
-    				return fStageComplete(false);
-    			}
-    
-    			// It looks like this record was not authorized.  Send an error.
-    			var tmpError = {Code:405,Message:'UNAUTHORIZED ACCESS IS NOT ALLOWED'};
-    			tmpError.Scope = pRequest.DAL.scope;
-    			tmpError[pRequest.DAL.defaultIdentifier] = pRequest.Record[pRequest.DAL.defaultIdentifier];
-    			return fStageComplete(tmpError);
-    		},
-    		// 3a. INJECT: Query configuration
-    		function (fStageComplete)
-    		{
-    			pRequest.Query = pRequest.DAL.query;
-    			pRequest.BehaviorModifications.runBehavior('Update-QueryConfiguration', pRequest, fStageComplete);
-    		},
-    		function(fStageComplete)
-    		{
-    			//3b. Prepare update query
-    			var tmpQuery = pRequest.Query;
-    
-    			tmpQuery.setIDUser(pRequest.UserSession.UserID);
-    			tmpQuery.addRecord(pRequest.Record);
-    
-    			return fStageComplete(null, tmpQuery);
-    		},
-    		function(pPreparedQuery, fStageComplete)
-    		{
-    			//4. Do the update operation
-    			pRequest.DAL.doUpdate(pPreparedQuery,
-    				function(pError, pQuery, pReadQuery, pRecord)
-    				{
-    					if (!pRecord)
-    					{
-    						return fStageComplete('Error updating a record.');
-    					}
-    					
-    					pRequest.Record = pRecord;
-    
-    					pRequest.UpdatedRecords.push(pRecord);
-    
-    					//pRequest.CommonServices.log.info('Updated a record with ID '+pRecord[pRequest.DAL.defaultIdentifier]+'.', {SessionID:pRequest.UserSession.SessionID, RequestID:pRequest.RequestUUID, RequestURL:pRequest.url, Action:pRequest.DAL.scope+'-UpdateBulk'}, pRequest);
-    
-    					return fStageComplete(null);
-    				});
-    		},
-    		function(fStageComplete)
-    		{
-    			// INJECT: Post modification with record
-    			return pRequest.BehaviorModifications.runBehavior('Update-PostOperation', pRequest, fStageComplete);
-    		}
-    	], function(pError)
-    	{
-    		if (pError)
-    		{
-				if (typeof(pError) === 'object') pError = JSON.stringify(pError);
-				
-    			pRecordToModify.Error = 'Error updating record:'+pError;
+
+	libAsync.waterfall(
+		[
+			function(fStageComplete)
+			{
+				pRequest.Record = pRecordToModify;
+
+				if (typeof(pOptionalCachedUpdatingRecord) !== 'undefined')
+				{
+					// Use the cached updating record instead of reading a record.
+					return fStageComplete(false, pOptionalCachedUpdatingRecord);
+				}
+				else
+				{
+					var tmpQuery = pRequest.DAL.query;
+
+					// This is not overloadable.
+					tmpQuery.addFilter(pRequest.DAL.defaultIdentifier, pRecordToModify[pRequest.DAL.defaultIdentifier]);
+
+					// Load the record so we can do security checks on it
+					pRequest.DAL.doRead(tmpQuery,
+						function(pError, pQuery, pRecord)
+						{
+							if (!pError && !pRecord)
+							{
+								//short-circuit: Can't update a record that doesn't exist!
+								pError = 'Record not found.';
+							}
+
+							return fStageComplete(pError, pRecord);
+						});
+				}
+			},
+			function(pOriginalRecord, fStageComplete)
+			{
+				//send the original record to the Authorizer so it can verify ownership/etc
+				// TODO: Because the authorizer looks in the request for the record, we need to fix this somehow to work asynchronously.
+				pRequest.UpdatingRecord = pRecordToModify;
+				pRequest.Record = pOriginalRecord;
+
+				pRequest.Authorizers.authorizeRequest('Update', pRequest, function(err)
+					{
+						pRequest.Record = pRequest.UpdatingRecord;
+						return fStageComplete(err);
+					});
+			},
+			function(fStageComplete)
+			{
+				//2. INJECT: Record modification before update
+				pRequest.BehaviorModifications.runBehavior('Update-PreOperation', pRequest, fStageComplete);
+			},
+			function (fStageComplete)
+			{
+				if (pRequest.MeadowAuthorization)
+				{
+					return fStageComplete(false);
+				}
+
+				// It looks like this record was not authorized.  Send an error.
+				var tmpError = {Code:405,Message:'UNAUTHORIZED ACCESS IS NOT ALLOWED'};
+				tmpError.Scope = pRequest.DAL.scope;
+				tmpError[pRequest.DAL.defaultIdentifier] = pRequest.Record[pRequest.DAL.defaultIdentifier];
+				return fStageComplete(tmpError);
+			},
+			// 3a. INJECT: Query configuration
+			function (fStageComplete)
+			{
+				pRequest.Query = pRequest.DAL.query;
+				pRequest.BehaviorModifications.runBehavior('Update-QueryConfiguration', pRequest, fStageComplete);
+			},
+			function(fStageComplete)
+			{
+				//3b. Prepare update query
+				var tmpQuery = pRequest.Query;
+
+				tmpQuery.setIDUser(pRequest.UserSession.UserID);
+				tmpQuery.addRecord(pRequest.Record);
+
+				return fStageComplete(null, tmpQuery);
+			},
+			function(pPreparedQuery, fStageComplete)
+			{
+				//4. Do the update operation
+				pRequest.DAL.doUpdate(pPreparedQuery,
+					function(pError, pQuery, pReadQuery, pRecord)
+					{
+						if (!pRecord)
+						{
+							return fStageComplete('Error updating a record.');
+						}
+
+						pRequest.Record = pRecord;
+
+						pRequest.UpdatedRecords.push(pRecord);
+
+						//pRequest.CommonServices.log.info('Updated a record with ID '+pRecord[pRequest.DAL.defaultIdentifier]+'.', {SessionID:pRequest.UserSession.SessionID, RequestID:pRequest.RequestUUID, RequestURL:pRequest.url, Action:pRequest.DAL.scope+'-UpdateBulk'}, pRequest);
+
+						return fStageComplete(null);
+					});
+			},
+			function(fStageComplete)
+			{
+				// INJECT: Post modification with record
+				return pRequest.BehaviorModifications.runBehavior('Update-PostOperation', pRequest, fStageComplete);
+			}
+		], function(pError)
+		{
+			if (pError)
+			{
+				pRecordToModify.Error = 'Error updating record:'+pError;
 				pRequest.RecordUpdateError = true;
 				pRequest.RecordUpdateErrorMessage = pError;
-    			pRequest.UpdatedRecords.push(pRecordToModify);
-    			pRequest.CommonServices.log.error('Error updating record:'+pError, {SessionID:pRequest.UserSession.SessionID, RequestID:pRequest.RequestUUID, RequestURL:pRequest.url, Action:pRequest.DAL.scope+'-'+pRequest.MeadowOperation}, pRequest);
-    		}
-    
-    		return fCallback();
-    	});
+				pRequest.UpdatedRecords.push(pRecordToModify);
+				pRequest.CommonServices.log.error('Error updating record:'+pError, {SessionID:pRequest.UserSession.SessionID, RequestID:pRequest.RequestUUID, RequestURL:pRequest.url, Action:pRequest.DAL.scope+'-'+pRequest.MeadowOperation}, pRequest);
+			}
+
+			return fCallback();
+		});
 };
 
 module.exports = doUpdate;

--- a/test/MeadowEndpoints_basic_tests.js
+++ b/test/MeadowEndpoints_basic_tests.js
@@ -287,7 +287,7 @@ suite
 					function()
 					{
 						var tmpAuthorizers = require('../source/Meadow-Authorizers.js').new(libFable);
-						tmpAuthorizers.setAuthorizer('AlwaysAuthorize', 
+						tmpAuthorizers.setAuthorizer('AlwaysAuthorize',
 							function(pRequest, fComplete)
 							{
 								pRequest.MeadowAuthorization = true;
@@ -313,7 +313,7 @@ suite
 							{
 								Expect(tmpMockRequest.MeadowAuthorization).to.equal(false);
 							});
-						var tmpMockFullRequest = 
+						var tmpMockFullRequest =
 						{
 							UserSession:
 							{
@@ -326,7 +326,7 @@ suite
 								IDUser: 1
 							}
 						};
-						// Test that 
+						// Test that
 					}
 				);
 				test
@@ -335,7 +335,7 @@ suite
 					function()
 					{
 						var tmpAuthorizers = require('../source/Meadow-Authorizers.js').new(libFable);
-						var tmpMockFullRequest = 
+						var tmpMockFullRequest =
 						{
 							UserSession:
 							{
@@ -494,7 +494,7 @@ suite
 						.get('1.0/FableTest/2')
 						.end(
 							function (pError, pResponse)
-							{					
+							{
 								Expect(pResponse.text).to.contain('UNAUTHORIZED ACCESS IS NOT ALLOWED');
 								// Reset authorization
 								_Meadow.schemaFull.authorizer.Manager.Read = 'Allow';
@@ -1692,7 +1692,7 @@ suite
 								Expect(pRequest.Record.IDAnimal).to.equal(tmpRecord.IDAnimal);
 								return fComplete(false);
 							});
-						
+
 						_MeadowEndpoints.invokeEndpoint('Delete', tmpRecord, {UserSession: _MockSessionValidUser},
 							function(pError, pResponse)
 							{


### PR DESCRIPTION
The main motivation here is to protect the "Satchel" from cross-contamination from different `invokeEndpoint` queries in a single request. In theory, this could also be done in the client code, but it has other dependencies on this Satchel object. In that vein, there will a companion change addressing that. Really, this is just a bandaid that makes a best effort to ensure this state is isolated once handed off to `invokeEndpoint`.
Changes:
* Sanitize satchel on invoke.
* Fix unit test (by effectively reverting 4d0768c76484384deb87710b2d276c27002baead).
* Fix mixed tabs/spaces and remove trailing spaces.