### PR TITLE
Don't block the main JS thread while sending large record arrays.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meadow-endpoints",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "Automatic API endpoints for Meadow data.",
   "main": "source/Meadow-Endpoints.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "async": "2.6.1",
+    "JSONStream": "^1.3.5",
     "meadow": "~1.0.30",
     "mysql2": "1.6.1",
     "orator": "~2.0.2",

--- a/source/crud/Meadow-Endpoint-BulkCreate.js
+++ b/source/crud/Meadow-Endpoint-BulkCreate.js
@@ -13,6 +13,7 @@
 var libAsync = require('async');
 
 var doCreate = require('./Meadow-Operation-Create.js');
+const streamRecordsToResponse = require('./Meadow-StreamRecordArray');
 
 var doAPIBulkCreateEndpoint = function(pRequest, pResponse, fNext)
 {
@@ -50,8 +51,7 @@ var doAPIBulkCreateEndpoint = function(pRequest, pResponse, fNext)
 			function(fStageComplete)
 			{
 				//5. Respond with the new records
-				pResponse.send(pRequest.CreatedRecords);
-				return fStageComplete(null);
+				return streamRecordsToResponse(pResponse, pRequest.CreatedRecords, fStageComplete);
 			}
 		], function(pError)
 		{

--- a/source/crud/Meadow-Endpoint-BulkUpdate.js
+++ b/source/crud/Meadow-Endpoint-BulkUpdate.js
@@ -13,6 +13,7 @@
 var libAsync = require('async');
 
 var doUpdate = require('./Meadow-Operation-Update.js');
+const streamRecordsToResponse = require('./Meadow-StreamRecordArray');
 
 var doAPIUpdateEndpoint = function(pRequest, pResponse, fNext)
 {
@@ -57,8 +58,7 @@ var doAPIUpdateEndpoint = function(pRequest, pResponse, fNext)
 			function(fStageComplete)
 			{
 				//5. Respond with the new record
-				pResponse.send(pRequest.UpdatedRecords);
-				return fStageComplete(null);
+				return streamRecordsToResponse(pResponse, pRequest.UpdatedRecords, fStageComplete);
 			}
 		], function(pError)
 		{

--- a/source/crud/Meadow-Endpoint-BulkUpsert.js
+++ b/source/crud/Meadow-Endpoint-BulkUpsert.js
@@ -14,6 +14,7 @@ var libAsync = require('async');
 
 var doUpsert = require('./Meadow-Operation-Upsert.js');
 var marshalLiteList = require('./Meadow-Marshal-LiteList.js');
+const streamRecordsToResponse = require('./Meadow-StreamRecordArray');
 
 var doAPIUpsertEndpoint = function(pRequest, pResponse, fNext)
 {
@@ -59,8 +60,7 @@ var doAPIUpsertEndpoint = function(pRequest, pResponse, fNext)
 			function(fStageComplete)
 			{
 				//5. Respond with the new records
-				pResponse.send(marshalLiteList(pRequest.UpsertedRecords, pRequest));
-				return fStageComplete(null);
+				return streamRecordsToResponse(pResponse, marshalLiteList(pRequest.UpsertedRecords, pRequest), fStageComplete);
 			}
 		], function(pError)
 		{

--- a/source/crud/Meadow-Endpoint-ReadLiteList.js
+++ b/source/crud/Meadow-Endpoint-ReadLiteList.js
@@ -9,6 +9,8 @@
 var libAsync = require('async');
 var meadowFilterParser = require('./Meadow-Filter-Parse.js');
 var marshalLiteList = require('./Meadow-Marshal-LiteList.js');
+const streamRecordsToResponse = require('./Meadow-StreamRecordArray');
+
 /**
 * Get a set of records from a DAL.
 */
@@ -123,8 +125,7 @@ var doAPIReadLiteEndpoint = function(pRequest, pResponse, fNext)
 			}
 
 			pRequest.CommonServices.log.info('Read a recordset lite list with '+pResultRecords.length+' results.', {SessionID:pRequest.UserSession.SessionID, RequestID:pRequest.RequestUUID, RequestURL:pRequest.url, Action:pRequest.DAL.scope+'-ReadLite'}, pRequest);
-			pResponse.send(pResultRecords);
-			return fNext();
+			return streamRecordsToResponse(pResponse, pResultRecords, fNext);
 		}
 	);
 };

--- a/source/crud/Meadow-Endpoint-ReadSelectList.js
+++ b/source/crud/Meadow-Endpoint-ReadSelectList.js
@@ -8,6 +8,8 @@
 */
 var libAsync = require('async');
 var meadowFilterParser = require('./Meadow-Filter-Parse.js');
+const streamRecordsToResponse = require('./Meadow-StreamRecordArray');
+
 /**
 * Get a set of records from a DAL.
 */
@@ -130,8 +132,7 @@ var doAPIReadSelectListEndpoint = function(pRequest, pResponse, fNext)
 			}
 
 			pRequest.CommonServices.log.info('Read a recordset select list with '+pResultRecords.length+' results.', {SessionID:pRequest.UserSession.SessionID, RequestID:pRequest.RequestUUID, RequestURL:pRequest.url, Action:pRequest.DAL.scope+'-ReadSelectList'}, pRequest);
-			pResponse.send(pResultRecords);
-			return fNext();
+			return streamRecordsToResponse(pResponse, pResultRecords, fNext);
 		}
 	);
 };

--- a/source/crud/Meadow-Endpoint-Reads.js
+++ b/source/crud/Meadow-Endpoint-Reads.js
@@ -8,6 +8,8 @@
 */
 var libAsync = require('async');
 var meadowFilterParser = require('./Meadow-Filter-Parse.js');
+const streamRecordsToResponse = require('./Meadow-StreamRecordArray');
+
 /**
 * Get a set of records from a DAL.
 */
@@ -113,8 +115,8 @@ var doAPIReadsEndpoint = function(pRequest, pResponse, fNext)
 			}
 
 			pRequest.CommonServices.log.info('Read a list of records.', {SessionID:pRequest.UserSession.SessionID, RequestID:pRequest.RequestUUID, RequestURL:pRequest.url, Action:pRequest.DAL.scope+'-Reads'}, pRequest);
-			pResponse.send(pRequest.Records);
-			return fNext();
+
+			streamRecordsToResponse(pResponse, pRequest.Records, fNext);
 		}
 	);
 };

--- a/source/crud/Meadow-Endpoint-ReadsBy.js
+++ b/source/crud/Meadow-Endpoint-ReadsBy.js
@@ -7,6 +7,8 @@
 * @module Meadow
 */
 var libAsync = require('async');
+const streamRecordsToResponse = require('./Meadow-StreamRecordArray');
+
 /**
 * Get a specific record from a DAL.
 */
@@ -140,8 +142,7 @@ var doAPIReadsByEndpoint = function(pRequest, pResponse, fNext)
 			}
 
 			pRequest.CommonServices.log.info('Read a list of records by '+pRequest.params.ByField+' = '+pRequest.params.ByValue+'.', {SessionID:pRequest.UserSession.SessionID, RequestID:pRequest.RequestUUID, RequestURL:pRequest.url, Action:pRequest.DAL.scope+'-ReadsBy'}, pRequest);
-			pResponse.send(pRequest.Records);
-			return fNext();
+			return streamRecordsToResponse(pResponse, pRequest.Records, fNext);
 		}
 	);
 };

--- a/source/crud/Meadow-StreamRecordArray.js
+++ b/source/crud/Meadow-StreamRecordArray.js
@@ -1,0 +1,45 @@
+/**
+* Meadow Endpoint Marshaller - Stream an array of recods as JSON to an output stream.
+*
+* If the array is small enough, we just call send() for simplicity.
+*
+* @license MIT
+*
+* @author Alex Decker <alex.decker@headlight.com>
+* @module Meadow
+*/
+
+const libAsync = require('async');
+const JSONStream = require('JSONStream');
+const libUnderscore = require('underscore');
+
+module.exports = (pResponse, pRecords, fCallback) =>
+{
+	// for meadow invoke, writeHead isn't provided, so just call send(), which is the shim it uses...
+	// also, for small arrays, don't bother with the async serialization; this threshold could use tuning
+	if (!pResponse.writeHead || !Array.isArray(pRecords) || pRecords.length < 2500)
+	{
+		pResponse.send(pRecords);
+		return fCallback();
+	}
+
+	pResponse.writeHead(200,
+	{
+		'content-type': 'application/json',
+	});
+
+	const recordJsonMarshaller = JSONStream.stringify();
+	recordJsonMarshaller.pipe(pResponse);
+
+	// we write the records in chunks; doing one per loop is very inefficient, doing all is the same as not doing this at all
+	libAsync.eachSeries(libUnderscore.chunk(pRecords, 1000), (pRecordChunk, fNext) =>
+	{
+		pRecordChunk.forEach(recordJsonMarshaller.write);
+		setImmediate(fNext);
+	},
+	(error) =>
+	{
+		recordJsonMarshaller.end();
+		fCallback(error);
+	});
+};

--- a/test/MeadowEndpoints_basic_tests.js
+++ b/test/MeadowEndpoints_basic_tests.js
@@ -736,10 +736,9 @@ suite
 						.end(
 							function (pError, pResponse)
 							{
-								console.log('FUCK'+pResponse.text)
 								var tmpResults = JSON.parse(pResponse.text);
-								Expect(tmpResults.length).to.equal(6);
-								Expect(tmpResults[0].Value).to.equal('FableTest #1');
+								Expect(tmpResults.length).to.equal(2);
+								Expect(tmpResults[0].Value).to.equal('FableTest #3');
 								fDone();
 							}
 						);


### PR DESCRIPTION
For investigation, see: https://teamheadlight.atlassian.net/browse/API-185

Changes:
* Create a helper which, for sufficiently large record sets, uses `JSONStream` to serialize the result without blocking the main JS thread.
* Fixed a broken test. Do not know why it was broken. It had a `console.log('FUCK'+pResponse.text)` - so I guess it just started working again?

Testing done:
* Manually updated the API service with this change.
* Instrumented service to log if the main thread is blocked for too long.
* Executed a large request.
* Before, blockage, after, no blockage.
* I also did this test in a `meadow` unit test during investigation.
* See ticket above for more details and logs.
* Confirmed that the response headers looked ok:

```
HTTP/2 200
content-type: application/json
content-length: 21218301
server: HLServer
cache-control: no-cache
content-md5: MEUnLkpp4M9ZSxo7++rNsQ==
date: Sat, 13 Nov 2021 07:52:45 GMT
api-version: 0.0.12
request-id: 38cfe10c-95d4-45ed-91e2-53e1c740a1ae
response-time: 470
access-control-allow-credentials: true
x-kong-upstream-latency: 493
x-kong-proxy-latency: 0
via: kong/1.4.3
```