### PR TITLE
Version bump to consume meadow-filter 1.0.4 which fixes FBLOR (which wasn't using OR) and adds FOPOR (which lets you join an open paren with an OR to its left).

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "meadow-endpoints",
-  "version": "2.0.16",
+  "version": "2.0.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.0.16",
+      "version": "2.0.19",
       "license": "MIT",
       "dependencies": {
         "async": "2.6.1",
         "JSONStream": "^1.3.5",
         "meadow": "~1.0.32",
-        "meadow-filter": "^1.0.1",
+        "meadow-filter": "^1.0.4",
         "orator": "~2.0.2",
         "underscore": "1.9.1"
       },
@@ -2874,9 +2874,9 @@
       }
     },
     "node_modules/meadow-filter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/meadow-filter/-/meadow-filter-1.0.1.tgz",
-      "integrity": "sha512-c0E1IC+FwVP+iFWwxo+FM7k9xEwbiEGaianQiDnm0AneYF1Kp9WbUEbJy7QN6IB8dQJD+7GYs21xLuP5okC/Mg=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/meadow-filter/-/meadow-filter-1.0.4.tgz",
+      "integrity": "sha512-lbzZG9cJhCOe3IWHVUJ/USy8o6eSZoiclrr2tzLdL9RF6UZzu3BvpK9JS92WzaZbS75fGvegRWc7dBJjuLEmOw=="
     },
     "node_modules/meadow/node_modules/async": {
       "version": "2.4.0",
@@ -7580,9 +7580,9 @@
       }
     },
     "meadow-filter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/meadow-filter/-/meadow-filter-1.0.1.tgz",
-      "integrity": "sha512-c0E1IC+FwVP+iFWwxo+FM7k9xEwbiEGaianQiDnm0AneYF1Kp9WbUEbJy7QN6IB8dQJD+7GYs21xLuP5okC/Mg=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/meadow-filter/-/meadow-filter-1.0.4.tgz",
+      "integrity": "sha512-lbzZG9cJhCOe3IWHVUJ/USy8o6eSZoiclrr2tzLdL9RF6UZzu3BvpK9JS92WzaZbS75fGvegRWc7dBJjuLEmOw=="
     },
     "methods": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meadow-endpoints",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "description": "Automatic API endpoints for Meadow data.",
   "main": "source/Meadow-Endpoints.js",
   "scripts": {
@@ -55,7 +55,7 @@
     "async": "2.6.1",
     "JSONStream": "^1.3.5",
     "meadow": "~1.0.32",
-    "meadow-filter": "^1.0.1",
+    "meadow-filter": "^1.0.4",
     "orator": "~2.0.2",
     "underscore": "1.9.1"
   }


### PR DESCRIPTION
Added a test for this case to meadow-filter (already published).

Ran coverage tests for `meadow-endpoints`.

```
  109 passing (598ms)

--------------------------------------|---------|----------|---------|---------|-----------------------------
File                                  | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
--------------------------------------|---------|----------|---------|---------|-----------------------------
All files                             |    90.9 |    78.11 |   96.69 |   90.87 |
 source                               |   93.47 |    78.91 |    90.9 |   93.45 |
  Meadow-Authenticator.js             |     100 |      100 |     100 |     100 |
  Meadow-Authorizers.js               |      92 |    90.62 |      90 |      92 | 95,108,165-168
  Meadow-BehaviorModifications.js     |     100 |      100 |     100 |     100 |
  Meadow-CommonServices.js            |   95.58 |    73.33 |      80 |   95.58 | 171,178,184
  Meadow-Endpoints.js                 |   94.57 |    71.66 |   89.65 |   94.54 | 239-242,424,443-444,452,596
  Restify-RouteParser.js              |   83.01 |    68.18 |     100 |   83.01 | 20,26-30,52,74,79-80,91
 source/authorizers                   |   72.22 |    76.92 |     100 |   72.22 |
  Meadow-Authorizer-Allow.js          |     100 |      100 |     100 |     100 |
  Meadow-Authorizer-Deny.js           |     100 |      100 |     100 |     100 |
  Meadow-Authorizer-Mine.js           |   64.28 |       75 |     100 |   64.28 | 15-16,21-22,41
  Meadow-Authorizer-MyCustomer.js     |   64.28 |    78.57 |     100 |   64.28 | 15-16,21-22,42
 source/crud                          |   90.05 |    77.18 |   98.81 |   90.01 |
  Meadow-Endpoint-BulkCreate.js       |      90 |       50 |     100 |      90 | 31,60
  Meadow-Endpoint-BulkUpdate.js       |   85.71 |       50 |     100 |   85.71 | 29,43,67
  Meadow-Endpoint-BulkUpsert.js       |    87.5 |       50 |     100 |    87.5 | 29,45,69
  Meadow-Endpoint-Count.js            |   96.29 |       90 |     100 |   96.29 | 40
  Meadow-Endpoint-CountBy.js          |   96.29 |     87.5 |     100 |   96.29 | 26
  Meadow-Endpoint-Create.js           |     100 |      100 |     100 |     100 |
  Meadow-Endpoint-Delete.js           |   90.24 |    83.33 |     100 |   90.24 | 35,43,76-77
  Meadow-Endpoint-Read.js             |     100 |      100 |     100 |     100 |
  Meadow-Endpoint-ReadDistinctList.js |   86.95 |    70.83 |     100 |   86.95 | 28,65,72,98,121,137
  Meadow-Endpoint-ReadLiteList.js     |   80.48 |    63.63 |     100 |   80.48 | 28,44,49,60,64,89,112,130
  Meadow-Endpoint-ReadMax.js          |   84.61 |       50 |     100 |   84.61 | 22,58-59,76
  Meadow-Endpoint-ReadSelectList.js   |     100 |      100 |     100 |     100 |
  Meadow-Endpoint-Reads.js            |      90 |       85 |     100 |      90 | 25,60,85-86
  Meadow-Endpoint-ReadsBy.js          |   93.18 |     90.9 |     100 |   93.18 | 26,112-113
  Meadow-Endpoint-Update.js           |   91.66 |       80 |     100 |   91.66 | 42,46
  Meadow-Endpoint-Upsert.js           |   83.33 |       50 |     100 |   83.33 | 28,44,62,71
  Meadow-Marshal-DistinctList.js      |   90.47 |    58.33 |     100 |      90 | 16,34
  Meadow-Marshal-LiteList.js          |    93.1 |    71.42 |     100 |   92.85 | 16,44
  Meadow-Operation-Create.js          |     100 |    78.57 |     100 |     100 | 16-29
  Meadow-Operation-Update.js          |   95.83 |    77.77 |     100 |   95.83 | 23,51
  Meadow-Operation-Upsert.js          |   75.67 |    70.83 |     100 |   75.67 | 42-43,60,77,95-99
  Meadow-StreamRecordArray.js         |   46.66 |       80 |   33.33 |   46.66 | 26-43
 source/schema                        |     100 |      100 |     100 |     100 |
  Meadow-Endpoint-New.js              |     100 |      100 |     100 |     100 |
  Meadow-Endpoint-Schema.js           |     100 |      100 |     100 |     100 |
  Meadow-Endpoint-Validate.js         |     100 |      100 |     100 |     100 |
--------------------------------------|---------|----------|---------|---------|-----------------------------
```